### PR TITLE
feat(ui): Esc-to-close, arrow-key message nav, DLQ reason column

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ With that in mind, feel free to suggest / make improvements - i'm not particular
 - Browse queues, topics and subscriptions in a simple tree.
 - Peek active and dead-letter messages with paging and optional live refresh.
 - View message details and resubmit from DLQ; optionally remove the original from DLQ.
+- Step through messages with the arrow keys and close any dialog with Esc.
 - Send to queues or topics with custom properties, content type, and scheduling; send multiple with an interval.
 - Manage subscriptions and rules (SQL and correlation) with create/delete.
 - Edit entity defaults (TTL and dead-letter on expiration) for queues, topics, subscriptions.
@@ -39,7 +40,7 @@ Navigate queues, topics, and subscriptions with an expandable tree and a clear s
 
 ### Queue management + message visibility
 
-Edit entity settings, inspect active messages, and review DLQ rows in one place.
+Edit entity settings, inspect active messages, and review DLQ rows (with dead-letter reason) in one place.
 
 ![Queue view](docs/features-04-queue.png)
 

--- a/src/Vibes.ASBManager.Application/Models/MessagePreview.cs
+++ b/src/Vibes.ASBManager.Application/Models/MessagePreview.cs
@@ -7,4 +7,5 @@ public sealed class MessagePreview
     public string? MessageId { get; init; }
     public string? Subject { get; init; }
     public string? CorrelationId { get; init; }
+    public string? DeadLetterReason { get; init; }
 }

--- a/src/Vibes.ASBManager.Infrastructure.AzureServiceBus/ServiceBus/AzureServiceBusMessaging.cs
+++ b/src/Vibes.ASBManager.Infrastructure.AzureServiceBus/ServiceBus/AzureServiceBusMessaging.cs
@@ -136,7 +136,8 @@ public sealed class AzureServiceBusMessaging(
         EnqueuedTime = message.EnqueuedTime,
         MessageId = message.MessageId,
         Subject = message.Subject,
-        CorrelationId = message.CorrelationId
+        CorrelationId = message.CorrelationId,
+        DeadLetterReason = message.DeadLetterReason
     };
 
     // Pages a snapshot behind a SINGLE receiver: the shared pager advances the peek anchor and we

--- a/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
+++ b/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
@@ -12,14 +12,14 @@
             <MudTh>Seq</MudTh>
             <MudTh>Dead-lettered</MudTh>
             <MudTh>MessageId</MudTh>
-            <MudTh>Subject</MudTh>
+            <MudTh>DLQ Reason</MudTh>
             <MudTh>CorrelationId</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Seq">@context.SequenceNumber</MudTd>
             <MudTd DataLabel="Dead-lettered">@context.EnqueuedTime.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")</MudTd>
             <MudTd DataLabel="MessageId">@context.MessageId</MudTd>
-            <MudTd DataLabel="Subject">@context.Subject</MudTd>
+            <MudTd DataLabel="DLQ Reason">@context.DeadLetterReason</MudTd>
             <MudTd DataLabel="CorrelationId">@context.CorrelationId</MudTd>
         </RowTemplate>
         <PagerContent>

--- a/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
+++ b/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
@@ -71,33 +71,41 @@ public partial class EntitiesView
     private async Task OnActiveRowClick(TableRowClickEventArgs<MessagePreview> args)
     {
         if (args?.Item is null) return;
-        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: false);
+        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: false, _messages.ActiveMessages.ToList());
     }
 
     private async Task OnDlqRowClick(TableRowClickEventArgs<MessagePreview> args)
     {
         if (args?.Item is null) return;
-        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: true);
+        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: true, _messages.DlqMessages.ToList());
     }
 
-    private async Task ShowMessageDetailsAsync(long sequenceNumber, bool isDeadLetter)
+    // Peek a single message's full details for the current tree selection. Shared by the initial
+    // open and by prev/next navigation inside the dialog.
+    private Task<MessageDetails?> PeekDetailsAsync(long sequenceNumber, bool isDeadLetter)
+    {
+        if (string.IsNullOrWhiteSpace(_connectionString)) return Task.FromResult<MessageDetails?>(null);
+        if (TryGetQueue(out var q))
+        {
+            return isDeadLetter
+                ? MessageBrowser.PeekQueueDeadLetterMessageAsync(_connectionString!, q, sequenceNumber)
+                : MessageBrowser.PeekQueueMessageAsync(_connectionString!, q, sequenceNumber);
+        }
+        if (TryGetSubscription(out var t, out var s))
+        {
+            return isDeadLetter
+                ? MessageBrowser.PeekSubscriptionDeadLetterMessageAsync(_connectionString!, t, s, sequenceNumber)
+                : MessageBrowser.PeekSubscriptionMessageAsync(_connectionString!, t, s, sequenceNumber);
+        }
+        return Task.FromResult<MessageDetails?>(null);
+    }
+
+    private async Task ShowMessageDetailsAsync(long sequenceNumber, bool isDeadLetter, IReadOnlyList<MessagePreview> previews)
     {
         if (string.IsNullOrWhiteSpace(_connectionString)) return;
         try
         {
-            MessageDetails? details = null;
-            if (TryGetQueue(out var q))
-            {
-                details = isDeadLetter
-                    ? await MessageBrowser.PeekQueueDeadLetterMessageAsync(_connectionString!, q, sequenceNumber)
-                    : await MessageBrowser.PeekQueueMessageAsync(_connectionString!, q, sequenceNumber);
-            }
-            else if (TryGetSubscription(out var t, out var s))
-            {
-                details = isDeadLetter
-                    ? await MessageBrowser.PeekSubscriptionDeadLetterMessageAsync(_connectionString!, t, s, sequenceNumber)
-                    : await MessageBrowser.PeekSubscriptionMessageAsync(_connectionString!, t, s, sequenceNumber);
-            }
+            var details = await PeekDetailsAsync(sequenceNumber, isDeadLetter);
 
             if (details is null)
             {
@@ -109,7 +117,9 @@ public partial class EntitiesView
             {
                 ["Details"] = details,
                 ["IsDeadLetter"] = isDeadLetter,
-                ["ConnectionString"] = _connectionString!
+                ["ConnectionString"] = _connectionString!,
+                ["Previews"] = previews,
+                ["LoadDetails"] = (Func<long, Task<MessageDetails?>>)(seq => PeekDetailsAsync(seq, isDeadLetter))
             };
             if (TryGetQueue(out var qq))
             {

--- a/src/Vibes.ASBManager.Web/Shared/MainLayout.razor
+++ b/src/Vibes.ASBManager.Web/Shared/MainLayout.razor
@@ -15,7 +15,7 @@
 
 <MudThemeProvider Theme="@CeruleanTheme" IsDarkMode="@_isDarkMode" />
 <MudPopoverProvider />
-<MudDialogProvider />
+<MudDialogProvider CloseOnEscapeKey="true" />
 <MudSnackbarProvider />
 
 <MudLayout>

--- a/src/Vibes.ASBManager.Web/Shared/MessageDetailsDialog.razor
+++ b/src/Vibes.ASBManager.Web/Shared/MessageDetailsDialog.razor
@@ -1,4 +1,5 @@
 @inherits ComponentBase
+@implements IAsyncDisposable
 @using System.Text.Json
 @using System.Xml.Linq
 @using Vibes.ASBManager.Application.Interfaces.Messaging
@@ -6,7 +7,18 @@
 
 <MudDialog>
     <DialogContent>
-        <MudText Typo="Typo.h6">Message @Details.SequenceNumber</MudText>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.h6">Message @Details.SequenceNumber</MudText>
+            @if (HasNav)
+            {
+                <MudSpacer />
+                <MudIconButton Icon="@Icons.Material.Filled.KeyboardArrowUp" Size="Size.Small" title="Previous (↑)"
+                               Disabled="@(_navigating || CurrentIndex <= 0)" OnClick="@(() => NavigateAsync(-1))" />
+                <MudText Typo="Typo.caption">@(CurrentIndex + 1) / @Previews!.Count</MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.KeyboardArrowDown" Size="Size.Small" title="Next (↓)"
+                               Disabled="@(_navigating || CurrentIndex >= Previews!.Count - 1)" OnClick="@(() => NavigateAsync(1))" />
+            }
+        </MudStack>
         <MudText Typo="Typo.caption" Class="mb-2">@(IsDeadLetter ? "Dead-lettered" : "Active")</MudText>
 
         <MudGrid Class="mb-2">
@@ -106,6 +118,11 @@
     [Parameter] public string? TopicName { get; set; }
     [Parameter] public string? SubscriptionName { get; set; }
 
+    // Ordered snapshot of the list this message was opened from, and a fetcher to load a
+    // sibling's details by sequence number — together they power prev/next (buttons + arrow keys).
+    [Parameter] public IReadOnlyList<MessagePreview>? Previews { get; set; }
+    [Parameter] public Func<long, Task<MessageDetails?>>? LoadDetails { get; set; }
+
     [Inject] private IMessageSender MessageSender { get; set; } = default!;
     [Inject] private IDeadLetterMaintenance DeadLetterMaintenance { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
@@ -122,6 +139,22 @@
     private string? _messageIdEdit;
     private bool _removeOriginal;
     private bool _generateNewMessageId;
+    private bool _navigating;
+    private DotNetObjectReference<MessageDetailsDialog>? _selfRef;
+    private IJSObjectReference? _keyNav;
+
+    private bool HasNav => Previews is { Count: > 1 } && LoadDetails is not null;
+
+    private int CurrentIndex
+    {
+        get
+        {
+            if (Previews is null) return -1;
+            for (var i = 0; i < Previews.Count; i++)
+                if (Previews[i].SequenceNumber == Details.SequenceNumber) return i;
+            return -1;
+        }
+    }
 
     private string FormatDate(DateTimeOffset dto) => dto.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
@@ -132,16 +165,89 @@
         if (!_initialized && Details is not null)
         {
             _initialized = true;
-            _bodyEdit = Details.Body;
-            _subjectEdit = Details.Subject;
-            _correlationIdEdit = Details.CorrelationId;
-            _contentTypeEdit = Details.ContentType;
-            _messageIdEdit = Details.MessageId;
-            _propertyDict = Details.ApplicationProperties?.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? string.Empty)
-                           ?? new Dictionary<string, string>(StringComparer.Ordinal);
-            TryFormatBodyForDisplay();
-            BuildSystemProps();
+            InitFromDetails();
         }
+    }
+
+    private void InitFromDetails()
+    {
+        _bodyEdit = Details.Body;
+        _subjectEdit = Details.Subject;
+        _correlationIdEdit = Details.CorrelationId;
+        _contentTypeEdit = Details.ContentType;
+        _messageIdEdit = Details.MessageId;
+        _propertyDict = Details.ApplicationProperties?.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString() ?? string.Empty)
+                       ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        TryFormatBodyForDisplay();
+        BuildSystemProps();
+    }
+
+    // direction: -1 = previous, +1 = next. Swaps the dialog to the sibling message in place.
+    private async Task NavigateAsync(int direction)
+    {
+        if (!HasNav || _navigating) return;
+        var idx = CurrentIndex;
+        if (idx < 0) return;
+        var next = idx + direction;
+        if (next < 0 || next >= Previews!.Count) return;
+        try
+        {
+            _navigating = true;
+            var details = await LoadDetails!(Previews[next].SequenceNumber);
+            if (details is null)
+            {
+                Snackbar.Add("Message not found. It may have moved or expired.", Severity.Info);
+                return;
+            }
+            Details = details;
+            InitFromDetails();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to load message: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _navigating = false;
+        }
+    }
+
+    [JSInvokable]
+    public Task Navigate(int direction)
+        => InvokeAsync(async () => { await NavigateAsync(direction); StateHasChanged(); });
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && HasNav)
+        {
+            try
+            {
+                _selfRef = DotNetObjectReference.Create(this);
+                _keyNav = await Js.InvokeAsync<IJSObjectReference>("import", "./keynav.js");
+                await _keyNav.InvokeVoidAsync("register", _selfRef);
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogDebug(ex, "Failed to register message key navigation.");
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_keyNav is not null)
+            {
+                await _keyNav.InvokeVoidAsync("unregister");
+                await _keyNav.DisposeAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger?.LogDebug(ex, "Failed to dispose message key navigation.");
+        }
+        _selfRef?.Dispose();
     }
 
     private string GetTargetLabel()

--- a/src/Vibes.ASBManager.Web/wwwroot/keynav.js
+++ b/src/Vibes.ASBManager.Web/wwwroot/keynav.js
@@ -1,0 +1,30 @@
+// Arrow-key navigation for the message dialog. Invokes the .NET Navigate(direction)
+// method on Left/Up (previous) and Right/Down (next) — but stays out of the way while
+// the user is editing, so arrows keep their normal meaning inside inputs/textareas.
+let handler = null;
+
+export function register(dotnet) {
+    unregister();
+    handler = (e) => {
+        if (e.altKey || e.ctrlKey || e.metaKey) return;
+        let dir;
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') dir = -1;
+        else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') dir = 1;
+        else return;
+
+        const el = document.activeElement;
+        const tag = el && el.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el && el.isContentEditable)) return;
+
+        e.preventDefault();
+        dotnet.invokeMethodAsync('Navigate', dir);
+    };
+    document.addEventListener('keydown', handler);
+}
+
+export function unregister() {
+    if (handler) {
+        document.removeEventListener('keydown', handler);
+        handler = null;
+    }
+}


### PR DESCRIPTION
Three QoL improvements to message browsing.

## Changes
- **Esc closes any dialog** — one global attribute (`MudDialogProvider.CloseOnEscapeKey`), so it applies to every popup, not just message details.
- **Arrow-key navigation** through messages in the details dialog — ←/↑ previous, →/↓ next, plus prev/next buttons and an `n / total` indicator. A document-level keydown listener (`wwwroot/keynav.js`) skips inputs/textareas, so arrows still move the cursor when editing a DLQ message body. The dialog receives a snapshot of the source list and a peek-by-sequence fetcher.
- **DLQ table shows the dead-letter reason** instead of Subject — added `DeadLetterReason` to `MessagePreview` and populated it in `ToPreview` (the SDK already exposes it; it was only surfaced in the details view before).

## Notes
- README "Key features" updated; screenshots not regenerated (only a column header changed).
- No new tests: navigation is bounds-checked with disabled buttons + a null-guard on missing messages, and there's no component-test harness in the repo to justify adding one for the index math.

Build clean, 75 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)