### PR TITLE
feat(dlq): search messages by id, subject, DL reason, and body

### DIFF
--- a/src/Vibes.ASBManager.Application/Messaging/MessageSearch.cs
+++ b/src/Vibes.ASBManager.Application/Messaging/MessageSearch.cs
@@ -1,0 +1,26 @@
+using Vibes.ASBManager.Application.Models;
+
+namespace Vibes.ASBManager.Application.Messaging;
+
+// Case-insensitive substring search across a message preview's human-readable fields. An empty or
+// whitespace term matches everything (i.e. no active filter). Kept pure so it can be unit-tested and
+// shared: the DLQ table uses it to filter what's shown, and the details dialog uses the same predicate
+// to build its prev/next navigation set so arrow keys stay within the search results.
+public static class MessageSearch
+{
+    public static bool Matches(MessagePreview message, string? term)
+    {
+        if (string.IsNullOrWhiteSpace(term)) return true;
+        if (message is null) return false;
+
+        var t = term.Trim();
+        return Contains(message.CorrelationId, t)
+            || Contains(message.Subject, t)
+            || Contains(message.DeadLetterReason, t)
+            || Contains(message.MessageId, t)
+            || Contains(message.Body, t);
+    }
+
+    private static bool Contains(string? value, string term)
+        => value is not null && value.Contains(term, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Vibes.ASBManager.Application/Models/MessagePreview.cs
+++ b/src/Vibes.ASBManager.Application/Models/MessagePreview.cs
@@ -8,4 +8,5 @@ public sealed class MessagePreview
     public string? Subject { get; init; }
     public string? CorrelationId { get; init; }
     public string? DeadLetterReason { get; init; }
+    public string? Body { get; init; }
 }

--- a/src/Vibes.ASBManager.Infrastructure.AzureServiceBus/ServiceBus/AzureServiceBusMessaging.cs
+++ b/src/Vibes.ASBManager.Infrastructure.AzureServiceBus/ServiceBus/AzureServiceBusMessaging.cs
@@ -137,8 +137,18 @@ public sealed class AzureServiceBusMessaging(
         MessageId = message.MessageId,
         Subject = message.Subject,
         CorrelationId = message.CorrelationId,
-        DeadLetterReason = message.DeadLetterReason
+        DeadLetterReason = message.DeadLetterReason,
+        Body = TryReadBody(message)
     };
+
+    // DLQ messages can carry non-Data AMQP bodies (Value/Sequence) whose .Body getter throws — and a
+    // malformed body is often *why* a message dead-lettered. One bad message must not sink the whole
+    // snapshot. ponytail: swallow — the body is search-only in the preview; details view reads it fresh.
+    private static string? TryReadBody(ServiceBusReceivedMessage message)
+    {
+        try { return message.Body?.ToString(); }
+        catch { return null; }
+    }
 
     // Pages a snapshot behind a SINGLE receiver: the shared pager advances the peek anchor and we
     // pass it straight to PeekMessagesAsync on the same receiver, so a 500-message refresh issues

--- a/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
+++ b/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
@@ -1,13 +1,25 @@
+@using Vibes.ASBManager.Application.Messaging
+
 <MudPaper Class="pa-3 mt-3" Elevation="1">
     <div class="d-flex align-center mb-2" style="gap:8px;">
-        <MudText Typo="Typo.h6">Dead-letter Messages @((Count.HasValue ? $"({Count.Value})" : string.Empty))</MudText>
+        <MudText Typo="Typo.h6">Dead-letter Messages @HeaderCount</MudText>
         <MudSpacer />
+        <MudTextField T="string" @bind-Value="_search" Immediate="true" Clearable="true"
+                      Placeholder="Search id, subject, reason, body…"
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                      Margin="Margin.Dense" Class="mt-0" Style="max-width:340px;" />
         <MudButton Variant="Variant.Outlined" Disabled="@(!CanRefresh)" OnClick="@OnRefresh">
             <MudIcon Icon="@Icons.Material.Filled.Refresh" />
             <span class="ms-1">Refresh</span>
         </MudButton>
     </div>
-    <MudTable T="MessagePreview" Items="Items" Dense="true" Hover="true" Elevation="0" OnRowClick="@OnRowClick">
+    @if (ShowScopeHint)
+    {
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1 d-block">
+            Searching the @_loadedCount loaded messages (of @Count). Refresh or narrow the selection to search more.
+        </MudText>
+    }
+    <MudTable T="MessagePreview" Items="FilteredItems" Dense="true" Hover="true" Elevation="0" OnRowClick="@HandleRowClick">
         <HeaderContent>
             <MudTh>Seq</MudTh>
             <MudTh>Dead-lettered</MudTh>
@@ -22,6 +34,9 @@
             <MudTd DataLabel="DLQ Reason">@context.DeadLetterReason</MudTd>
             <MudTd DataLabel="CorrelationId">@context.CorrelationId</MudTd>
         </RowTemplate>
+        <NoRecordsContent>
+            <MudText Typo="Typo.body2">@NoRecordsText</MudText>
+        </NoRecordsContent>
         <PagerContent>
             <MudTablePager PageSizeOptions="new int[] { 10, 15, 25, 50 }" />
         </PagerContent>
@@ -33,6 +48,34 @@
     [Parameter] public bool CanRefresh { get; set; }
     [Parameter] public EventCallback OnRefresh { get; set; }
 
-    [Parameter] public EventCallback<TableRowClickEventArgs<MessagePreview>> OnRowClick { get; set; }
+    // Carries the clicked message plus the currently-visible (filtered) set, so the details dialog can
+    // navigate prev/next within the search results rather than the whole loaded snapshot.
+    [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnRowClick { get; set; }
     [Parameter] public long? Count { get; set; }
+
+    private string? _search;
+
+    private int _loadedCount => Items?.Count ?? 0;
+
+    private IReadOnlyList<MessagePreview> FilteredItems
+        => string.IsNullOrWhiteSpace(_search) || Items is null
+            ? Items ?? Array.Empty<MessagePreview>()
+            : Items.Where(m => MessageSearch.Matches(m, _search)).ToList();
+
+    private string HeaderCount
+        => !string.IsNullOrWhiteSpace(_search)
+            ? $"(showing {FilteredItems.Count} of {_loadedCount})"
+            : Count.HasValue ? $"({Count.Value})" : string.Empty;
+
+    private bool ShowScopeHint
+        => !string.IsNullOrWhiteSpace(_search) && Count.HasValue && _loadedCount < Count.Value;
+
+    private string NoRecordsText
+        => string.IsNullOrWhiteSpace(_search) ? "No dead-letter messages." : "No messages match your search.";
+
+    private async Task HandleRowClick(TableRowClickEventArgs<MessagePreview> args)
+    {
+        if (args?.Item is null) return;
+        await OnRowClick.InvokeAsync((args.Item, FilteredItems));
+    }
 }

--- a/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
+++ b/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
@@ -74,10 +74,10 @@ public partial class EntitiesView
         await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: false, _messages.ActiveMessages.ToList());
     }
 
-    private async Task OnDlqRowClick(TableRowClickEventArgs<MessagePreview> args)
+    private async Task OnDlqRowClick((MessagePreview Item, IReadOnlyList<MessagePreview> Visible) args)
     {
-        if (args?.Item is null) return;
-        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: true, _messages.DlqMessages.ToList());
+        if (args.Item is null) return;
+        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: true, args.Visible);
     }
 
     // Peek a single message's full details for the current tree selection. Shared by the initial

--- a/src/Vibes.ASBManager.Web/Shared/MessageBrowserPanel.razor
+++ b/src/Vibes.ASBManager.Web/Shared/MessageBrowserPanel.razor
@@ -22,5 +22,5 @@
     [Parameter] public EventCallback OnActiveRefresh { get; set; }
     [Parameter] public EventCallback OnDlqRefresh { get; set; }
     [Parameter] public EventCallback<TableRowClickEventArgs<MessagePreview>> OnActiveRowClick { get; set; }
-    [Parameter] public EventCallback<TableRowClickEventArgs<MessagePreview>> OnDlqRowClick { get; set; }
+    [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnDlqRowClick { get; set; }
 }

--- a/tests/Vibes.ASBManager.Tests.Integration/PeekPagingTests.cs
+++ b/tests/Vibes.ASBManager.Tests.Integration/PeekPagingTests.cs
@@ -58,6 +58,12 @@ public sealed class PeekPagingTests(EmulatorFixture fixture)
         Assert.Equal(24, snapshot.Count);
         Assert.Equal(24, snapshot.Select(m => m.SequenceNumber).Distinct().Count());
 
+        // The preview must carry body + dead-letter reason through a real peek — that's what DLQ
+        // search filters on. Bodies were sent as "msg-{i}"; the reason was set to "test".
+        Assert.All(snapshot, m => Assert.False(string.IsNullOrEmpty(m.Body)));
+        Assert.All(snapshot, m => Assert.Equal("test", m.DeadLetterReason));
+        Assert.Contains(snapshot, m => m.Body == "msg-0");
+
         await messaging.PurgeQueueDeadLetterAsync(EmulatorFixture.ConnectionString, PlainQueue, maxMessages: 1000);
     }
 

--- a/tests/Vibes.ASBManager.Tests.Unit/Application/Messaging/MessageSearchTests.cs
+++ b/tests/Vibes.ASBManager.Tests.Unit/Application/Messaging/MessageSearchTests.cs
@@ -1,0 +1,64 @@
+using Vibes.ASBManager.Application.Messaging;
+using Vibes.ASBManager.Application.Models;
+
+namespace Vibes.ASBManager.Tests.Unit.Application.Messaging;
+
+public class MessageSearchTests
+{
+    private static MessagePreview Msg(
+        string? correlationId = null, string? subject = null,
+        string? deadLetterReason = null, string? messageId = null, string? body = null)
+        => new()
+        {
+            SequenceNumber = 1,
+            EnqueuedTime = DateTimeOffset.UnixEpoch,
+            CorrelationId = correlationId,
+            Subject = subject,
+            DeadLetterReason = deadLetterReason,
+            MessageId = messageId,
+            Body = body
+        };
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Empty_term_matches_everything(string? term)
+        => Assert.True(MessageSearch.Matches(Msg(subject: "anything"), term));
+
+    [Fact]
+    public void Matches_on_body_content()
+        => Assert.True(MessageSearch.Matches(Msg(body: "{\"orderId\":\"abc-123\"}"), "abc-123"));
+
+    [Fact]
+    public void Matches_on_dead_letter_reason()
+        => Assert.True(MessageSearch.Matches(Msg(deadLetterReason: "MaxDeliveryCountExceeded"), "maxdelivery"));
+
+    [Fact]
+    public void Matches_on_correlation_id()
+        => Assert.True(MessageSearch.Matches(Msg(correlationId: "corr-99"), "corr-99"));
+
+    [Fact]
+    public void Matches_on_subject()
+        => Assert.True(MessageSearch.Matches(Msg(subject: "OrderPlaced"), "orderplaced"));
+
+    [Fact]
+    public void Matches_on_message_id()
+        => Assert.True(MessageSearch.Matches(Msg(messageId: "msg-77"), "msg-77"));
+
+    [Fact]
+    public void Is_case_insensitive()
+        => Assert.True(MessageSearch.Matches(Msg(subject: "TimeoutError"), "TIMEOUT"));
+
+    [Fact]
+    public void Trims_surrounding_whitespace_from_the_term()
+        => Assert.True(MessageSearch.Matches(Msg(correlationId: "abc"), "  abc  "));
+
+    [Fact]
+    public void Returns_false_when_no_field_contains_the_term()
+        => Assert.False(MessageSearch.Matches(Msg(subject: "hello", body: "world"), "zzz"));
+
+    [Fact]
+    public void Null_fields_do_not_throw()
+        => Assert.False(MessageSearch.Matches(Msg(), "anything"));
+}


### PR DESCRIPTION
Adds text search to the dead-letter table — the DLQ-only search we scoped, over the loaded snapshot.

## What it does
- Search box in the DLQ header filters loaded rows live across **correlation id, subject, dead-letter reason, message id, and body** (case-insensitive substring).
- Header shows `showing N of M` while searching; a caption appears **only** when the snapshot didn't cover the whole DLQ (`loaded < runtime count`) — honest about the 500-message cap without implying it searched more.
- Arrow-key navigation in the details dialog stays **within** the filtered results: the table hands its visible set to the dialog, so prev/next walks your search results, not the whole snapshot.

## How it works
- `MessagePreview` gains `Body`. The body is already downloaded during peek — we just stopped discarding it. Populated via a guarded `TryReadBody` because a malformed body (often *why* a message dead-lettered) must not sink the whole snapshot.
- `MessageSearch.Matches` is a pure predicate, shared by the table filter and the dialog's navigation set so both agree on what "matching" means.

## Verification
- **12 unit tests** on `MessageSearch` (per-field matches, case-insensitivity, trim, null-safety, empty-term-matches-all).
- **Emulator integration** — extended the DLQ snapshot test to assert `Body` and `DeadLetterReason` survive a real peek, so body-search has real data. Ran the full suite against the emulator (10 passed, 0 skipped).

## Deferred (as scoped)
- Deep-scan for DLQs over 500 messages, and export — both build cleanly on this later.

## Not done
- UI click-test in a browser — search logic is unit-tested and data population is emulator-proven; the remaining surface is Blazor wiring, which compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)