### PR TITLE
refactor(messages): share table logic, add active-message search

### DIFF
--- a/src/Vibes.ASBManager.Web/Shared/ActiveMessagesTable.razor
+++ b/src/Vibes.ASBManager.Web/Shared/ActiveMessagesTable.razor
@@ -1,13 +1,25 @@
+@inherits MessageTableBase
+
 <MudPaper Class="pa-3 mt-3" Elevation="1">
     <div class="d-flex align-center mb-2" style="gap:8px;">
-        <MudText Typo="Typo.h6">Active Messages @((Count.HasValue ? $"({Count.Value})" : string.Empty))</MudText>
+        <MudText Typo="Typo.h6">Active Messages @CountSuffix</MudText>
         <MudSpacer />
+        <MudTextField T="string" @bind-Value="Search" Immediate="true" Clearable="true"
+                      Placeholder="Search id, subject, body…"
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                      Margin="Margin.Dense" Class="mt-0" Style="max-width:340px;" />
         <MudButton Variant="Variant.Outlined" Disabled="@(!CanRefresh)" OnClick="@OnRefresh">
             <MudIcon Icon="@Icons.Material.Filled.Refresh" />
             <span class="ms-1">Refresh</span>
         </MudButton>
     </div>
-    <MudTable T="MessagePreview" Items="Items" Dense="true" Hover="true" Elevation="0" OnRowClick="@OnRowClick">
+    @if (ShowScopeHint)
+    {
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1 d-block">
+            Searching the @LoadedCount loaded messages (of @Count). Refresh or narrow the selection to search more.
+        </MudText>
+    }
+    <MudTable T="MessagePreview" Items="FilteredItems" Dense="true" Hover="true" Elevation="0" OnRowClick="@HandleRowClick">
         <HeaderContent>
             <MudTh>Seq</MudTh>
             <MudTh>Enqueued</MudTh>
@@ -22,17 +34,11 @@
             <MudTd DataLabel="Subject">@context.Subject</MudTd>
             <MudTd DataLabel="CorrelationId">@context.CorrelationId</MudTd>
         </RowTemplate>
+        <NoRecordsContent>
+            <MudText Typo="Typo.body2">@NoRecordsText("No active messages.")</MudText>
+        </NoRecordsContent>
         <PagerContent>
             <MudTablePager PageSizeOptions="new int[] { 10, 15, 25, 50 }" />
         </PagerContent>
     </MudTable>
 </MudPaper>
-
-@code {
-    [Parameter] public IReadOnlyList<MessagePreview>? Items { get; set; }
-    [Parameter] public bool CanRefresh { get; set; }
-    [Parameter] public EventCallback OnRefresh { get; set; }
-
-    [Parameter] public EventCallback<TableRowClickEventArgs<MessagePreview>> OnRowClick { get; set; }
-    [Parameter] public long? Count { get; set; }
-}

--- a/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
+++ b/src/Vibes.ASBManager.Web/Shared/DlqMessagesTable.razor
@@ -1,10 +1,10 @@
-@using Vibes.ASBManager.Application.Messaging
+@inherits MessageTableBase
 
 <MudPaper Class="pa-3 mt-3" Elevation="1">
     <div class="d-flex align-center mb-2" style="gap:8px;">
-        <MudText Typo="Typo.h6">Dead-letter Messages @HeaderCount</MudText>
+        <MudText Typo="Typo.h6">Dead-letter Messages @CountSuffix</MudText>
         <MudSpacer />
-        <MudTextField T="string" @bind-Value="_search" Immediate="true" Clearable="true"
+        <MudTextField T="string" @bind-Value="Search" Immediate="true" Clearable="true"
                       Placeholder="Search id, subject, reason, body…"
                       Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
                       Margin="Margin.Dense" Class="mt-0" Style="max-width:340px;" />
@@ -16,7 +16,7 @@
     @if (ShowScopeHint)
     {
         <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1 d-block">
-            Searching the @_loadedCount loaded messages (of @Count). Refresh or narrow the selection to search more.
+            Searching the @LoadedCount loaded messages (of @Count). Refresh or narrow the selection to search more.
         </MudText>
     }
     <MudTable T="MessagePreview" Items="FilteredItems" Dense="true" Hover="true" Elevation="0" OnRowClick="@HandleRowClick">
@@ -35,47 +35,10 @@
             <MudTd DataLabel="CorrelationId">@context.CorrelationId</MudTd>
         </RowTemplate>
         <NoRecordsContent>
-            <MudText Typo="Typo.body2">@NoRecordsText</MudText>
+            <MudText Typo="Typo.body2">@NoRecordsText("No dead-letter messages.")</MudText>
         </NoRecordsContent>
         <PagerContent>
             <MudTablePager PageSizeOptions="new int[] { 10, 15, 25, 50 }" />
         </PagerContent>
     </MudTable>
 </MudPaper>
-
-@code {
-    [Parameter] public IReadOnlyList<MessagePreview>? Items { get; set; }
-    [Parameter] public bool CanRefresh { get; set; }
-    [Parameter] public EventCallback OnRefresh { get; set; }
-
-    // Carries the clicked message plus the currently-visible (filtered) set, so the details dialog can
-    // navigate prev/next within the search results rather than the whole loaded snapshot.
-    [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnRowClick { get; set; }
-    [Parameter] public long? Count { get; set; }
-
-    private string? _search;
-
-    private int _loadedCount => Items?.Count ?? 0;
-
-    private IReadOnlyList<MessagePreview> FilteredItems
-        => string.IsNullOrWhiteSpace(_search) || Items is null
-            ? Items ?? Array.Empty<MessagePreview>()
-            : Items.Where(m => MessageSearch.Matches(m, _search)).ToList();
-
-    private string HeaderCount
-        => !string.IsNullOrWhiteSpace(_search)
-            ? $"(showing {FilteredItems.Count} of {_loadedCount})"
-            : Count.HasValue ? $"({Count.Value})" : string.Empty;
-
-    private bool ShowScopeHint
-        => !string.IsNullOrWhiteSpace(_search) && Count.HasValue && _loadedCount < Count.Value;
-
-    private string NoRecordsText
-        => string.IsNullOrWhiteSpace(_search) ? "No dead-letter messages." : "No messages match your search.";
-
-    private async Task HandleRowClick(TableRowClickEventArgs<MessagePreview> args)
-    {
-        if (args?.Item is null) return;
-        await OnRowClick.InvokeAsync((args.Item, FilteredItems));
-    }
-}

--- a/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
+++ b/src/Vibes.ASBManager.Web/Shared/EntitiesView.MessageBrowser.cs
@@ -68,10 +68,10 @@ public partial class EntitiesView
         _sendCts = null;
     }
 
-    private async Task OnActiveRowClick(TableRowClickEventArgs<MessagePreview> args)
+    private async Task OnActiveRowClick((MessagePreview Item, IReadOnlyList<MessagePreview> Visible) args)
     {
-        if (args?.Item is null) return;
-        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: false, _messages.ActiveMessages.ToList());
+        if (args.Item is null) return;
+        await ShowMessageDetailsAsync(args.Item.SequenceNumber, isDeadLetter: false, args.Visible);
     }
 
     private async Task OnDlqRowClick((MessagePreview Item, IReadOnlyList<MessagePreview> Visible) args)

--- a/src/Vibes.ASBManager.Web/Shared/MessageBrowserPanel.razor
+++ b/src/Vibes.ASBManager.Web/Shared/MessageBrowserPanel.razor
@@ -21,6 +21,6 @@
 
     [Parameter] public EventCallback OnActiveRefresh { get; set; }
     [Parameter] public EventCallback OnDlqRefresh { get; set; }
-    [Parameter] public EventCallback<TableRowClickEventArgs<MessagePreview>> OnActiveRowClick { get; set; }
+    [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnActiveRowClick { get; set; }
     [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnDlqRowClick { get; set; }
 }

--- a/src/Vibes.ASBManager.Web/Shared/MessageTableBase.cs
+++ b/src/Vibes.ASBManager.Web/Shared/MessageTableBase.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Vibes.ASBManager.Application.Messaging;
+using Vibes.ASBManager.Application.Models;
+
+namespace Vibes.ASBManager.Web.Shared;
+
+// Shared behaviour for the active and dead-letter message tables: the live search box's filtering,
+// the "showing N of M" counts, and handing the currently-visible (filtered) set to the details dialog
+// on row click so its prev/next navigation stays within the search results. Each table supplies its
+// own markup — title, column labels, and the one column that differs (Subject vs DLQ Reason).
+public abstract class MessageTableBase : ComponentBase
+{
+    [Parameter] public IReadOnlyList<MessagePreview>? Items { get; set; }
+    [Parameter] public bool CanRefresh { get; set; }
+    [Parameter] public EventCallback OnRefresh { get; set; }
+
+    // Carries the clicked message plus the currently-visible (filtered) set, so the details dialog can
+    // navigate prev/next within the search results rather than the whole loaded snapshot.
+    [Parameter] public EventCallback<(MessagePreview Item, IReadOnlyList<MessagePreview> Visible)> OnRowClick { get; set; }
+    [Parameter] public long? Count { get; set; }
+
+    protected string? Search;
+
+    protected int LoadedCount => Items?.Count ?? 0;
+
+    protected IReadOnlyList<MessagePreview> FilteredItems
+        => string.IsNullOrWhiteSpace(Search) || Items is null
+            ? Items ?? Array.Empty<MessagePreview>()
+            : Items.Where(m => MessageSearch.Matches(m, Search)).ToList();
+
+    // Title suffix: matched/loaded while searching, else the runtime count.
+    protected string CountSuffix
+        => !string.IsNullOrWhiteSpace(Search)
+            ? $"(showing {FilteredItems.Count} of {LoadedCount})"
+            : Count.HasValue ? $"({Count.Value})" : string.Empty;
+
+    // Shown only when a search is active and the loaded snapshot didn't cover the whole entity.
+    protected bool ShowScopeHint
+        => !string.IsNullOrWhiteSpace(Search) && Count.HasValue && LoadedCount < Count.Value;
+
+    protected string NoRecordsText(string emptyLabel)
+        => string.IsNullOrWhiteSpace(Search) ? emptyLabel : "No messages match your search.";
+
+    protected async Task HandleRowClick(TableRowClickEventArgs<MessagePreview> args)
+    {
+        if (args?.Item is null) return;
+        await OnRowClick.InvokeAsync((args.Item, FilteredItems));
+    }
+}


### PR DESCRIPTION
Extends the DLQ search to active messages, and removes the duplication that adding it to both tables would have created.

## What changed
- **New `MessageTableBase`** holds the shared behaviour once — the live search filter, the `showing N of M` counts, the scope hint, and handing the visible (filtered) set to the details dialog on row click. Both tables now `@inherits` it and are just markup (title, columns, placeholder).
- **Active messages gain search** (id, subject, correlation id, body). It was nearly free: `Body` is already populated on the preview via the shared mapper, and `MessageSearch` already covers these fields. The DL-reason field simply stays null for active.
- **Active arrow-key nav now respects its filter too** — the active row-click carries the visible set, same as DLQ.

## Does it mess anything up?
No — each table keeps independent `Search` state, live-refresh re-filters as before, and the null DL-reason on active is a harmless no-op in the predicate.

## Notes
- Net **−31 lines** in the existing files despite the new feature: the logic lives once instead of being copy-pasted into both tables.
- Pure UI refactor over already-verified data — no SDK/peek change, so no emulator run. `Body` population was emulator-verified in #73.

Build clean (0 warnings), 87 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)